### PR TITLE
Fix missing parsing library dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 Install dependencies:
 ```
-  $ pip install beautifulsoup4
+$ pip install -r requirements.txt
 ```
 To run,
 ```
-  $ python driver.py
+$ python driver.py
 ```  
 This should download every html page to every problem on Codeforces to a text file in a folder
 called "texts" in your current directory.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+beautifulsoup4==4.6.0
+lxml==4.1.1


### PR DESCRIPTION
Resolution of dependencies currently fails with:

```
Traceback (most recent call last):
  File "driver.py", line 44, in <module>
    main()
  File "driver.py", line 40, in main
    import_cf()
  File "driver.py", line 25, in import_cf
    soup = BeautifulSoup(f, "lxml")
  File "/Users/jamestaylr/Desktop/codeforces-scraper/venv/lib/python3.6/site-packages/bs4/__init__.py", line 165, in __init__
    % ",".join(features))
bs4.FeatureNotFound: Couldn't find a tree builder with the features you requested: lxml. Do you need to install a parser library?
```

This adds the missing dependencies and freezes requirements.